### PR TITLE
Fix shop functionality and rebalance game difficulty

### DIFF
--- a/game.js
+++ b/game.js
@@ -2,14 +2,15 @@
 
 // --- GAME STATE ---
 let gameState = {
-    hp: 15,
-    maxHp: 15,
+    hp: 20,
+    maxHp: 20,
     silver: 0,
     points: 0,
     level: 1,
     inventory: [],
     currentMonster: null,
     inCombat: false,
+    inShop: false,
     gameStarted: false,
     roomsExplored: 0,
     bossEncountered: false
@@ -17,20 +18,20 @@ let gameState = {
 
 // --- GAME DATA ---
 const weakMonsters = [
-    { name: 'Blood-drenched Skeleton', points: 3, damage: 'd4', hp: 6, difficulty: 3 },
-    { name: 'Catacomb Cultist', points: 3, damage: 'd4', hp: 6, difficulty: 3 },
-    { name: 'Goblin', points: 3, damage: 'd4', hp: 5, difficulty: 3 },
-    { name: 'Undead Hound', points: 4, damage: 'd4', hp: 6, difficulty: 4 }
+    { name: 'Blood-drenched Skeleton', points: 3, damage: 'd4', hp: 6, difficulty: 2 },
+    { name: 'Catacomb Cultist', points: 3, damage: 'd4', hp: 6, difficulty: 2 },
+    { name: 'Goblin', points: 3, damage: 'd4', hp: 5, difficulty: 2 },
+    { name: 'Undead Hound', points: 4, damage: 'd4', hp: 6, difficulty: 3 }
 ];
 
 const toughMonsters = [
-    { name: 'Necro-Sorcerer', points: 4, damage: 'd6', hp: 8, difficulty: 4 },
-    { name: 'Small Stone Troll', points: 5, damage: 'd6', hp: 9, difficulty: 5 },
-    { name: 'Medusa', points: 4, damage: 'd6', hp: 10, difficulty: 4 },
-    { name: 'Ruin Basilisk', points: 4, damage: 'd6', hp: 11, difficulty: 4 }
+    { name: 'Necro-Sorcerer', points: 4, damage: 'd6', hp: 8, difficulty: 3 },
+    { name: 'Small Stone Troll', points: 5, damage: 'd6', hp: 9, difficulty: 4 },
+    { name: 'Medusa', points: 4, damage: 'd6', hp: 10, difficulty: 3 },
+    { name: 'Ruin Basilisk', points: 4, damage: 'd6', hp: 11, difficulty: 3 }
 ];
 
-const fortressLord = { name: 'Fortress Lord', points: 20, damage: 'd6', hp: 25, difficulty: 5 };
+const fortressLord = { name: 'Fortress Lord', points: 20, damage: 'd6', hp: 25, difficulty: 4 };
 
 const shopItems = [
     { name: 'Potion', price: 5, description: 'Heals d6 HP.' },
@@ -85,7 +86,7 @@ function updateUI() {
 
     // Buttons
     document.getElementById('startBtn').style.display = gameState.gameStarted ? 'none' : 'block';
-    document.getElementById('exploreBtn').style.display = gameState.gameStarted && !gameState.inCombat ? 'block' : 'none';
+    document.getElementById('exploreBtn').style.display = gameState.gameStarted && !gameState.inCombat && !gameState.inShop ? 'block' : 'none';
     document.getElementById('attackBtn').style.display = gameState.inCombat ? 'block' : 'none';
     document.getElementById('fleeBtn').style.display = gameState.inCombat ? 'block' : 'none';
     document.getElementById('usePotionBtn').style.display = gameState.gameStarted && gameState.inventory.includes('Potion') && gameState.hp < gameState.maxHp ? 'block' : 'none';
@@ -151,9 +152,9 @@ function exploreRoom() {
         log(`Encountered a ${monster.name}.`);
         startCombat(monster);
     } else { // Shop
-        text += "<p class='success'>A mysterious peddler appears, offering their wares.</p>";
         log("Found a shop.");
-        openShop();
+        openShop(true); // Open shop for the first time
+        return; // Return to prevent overwriting the shop UI
     }
     
     setGameText(text);
@@ -272,13 +273,19 @@ function usePotion() {
     }
 }
 
-function openShop() {
-    let shopText = "<h4>🛒 Peddler's Wares</h4>";
+function openShop(isFirstTime = false) {
+    gameState.inShop = true;
+    let shopText = "";
+    if (isFirstTime) {
+        shopText += "<p class='success'>A mysterious peddler appears, offering their wares.</p>";
+    }
+    shopText += "<h4>🛒 Peddler's Wares</h4>";
     shopItems.forEach(item => {
         shopText += `<p>${item.name} (${item.price}s): ${item.description} <button onclick="buyItem('${item.name}', ${item.price})" ${gameState.silver < item.price ? 'disabled' : ''}>Buy</button></p>`;
     });
     shopText += `<button onclick="closeShop()">Leave Shop</button>`;
     setGameText(shopText);
+    updateUI();
 }
 
 function buyItem(itemName, price) {
@@ -286,12 +293,12 @@ function buyItem(itemName, price) {
         gameState.silver -= price;
         gameState.inventory.push(itemName);
         log(`You bought a ${itemName}.`);
-        openShop(); // Refresh shop view
+        openShop(); // Refresh shop view without intro
     }
-    updateUI();
 }
 
 function closeShop() {
+    gameState.inShop = false;
     setGameText("<p>You leave the peddler behind and continue into the darkness.</p>");
     updateUI();
 }
@@ -339,14 +346,15 @@ function gameOver(reason) {
 
 function resetGame() {
     gameState = {
-        hp: 15,
-        maxHp: 15,
+        hp: 20,
+        maxHp: 20,
         silver: 0,
         points: 0,
         level: 1,
         inventory: [],
         currentMonster: null,
         inCombat: false,
+        inShop: false,
         gameStarted: false,
         roomsExplored: 0,
         bossEncountered: false


### PR DESCRIPTION
This commit addresses two issues:
1. The shop was previously unusable due to a bug where the shop UI was immediately overwritten. This has been fixed by introducing an `inShop` state that correctly handles the shop's visibility and interactivity.
2. The game was too difficult for new players. The player's starting HP has been increased from 15 to 20, and the difficulty of all monsters has been reduced by 1 to make combat more forgiving.