### PR TITLE
I've fixed a TypeError that occurred when playing sounds. The sfxr.js…

### DIFF
--- a/sounds.js
+++ b/sounds.js
@@ -2,12 +2,12 @@
 
 // A utility function to play a sound based on sfxr parameters
 function playSound(params) {
-    // Check if sfxr is loaded
-    if (typeof sfxr !== 'undefined') {
-        const sfx = new sfxr.SoundEffect(params);
+    // Check if jsfxr is loaded
+    if (typeof jsfxr !== 'undefined') {
+        const sfx = new jsfxr.SoundEffect(params);
         sfx.toAudio().play();
     } else {
-        console.warn("sfxr library not found. Sound disabled.");
+        console.warn("jsfxr library not found. Sound disabled.");
     }
 }
 


### PR DESCRIPTION
… library in your project exposes a global object named 'jsfxr', but the code was incorrectly referencing 'sfxr'.

To correct this, I updated the `playSound` function in `sounds.js` to use the proper `jsfxr` object, which resolves the "sfxr.SoundEffect is not a constructor" error.