### PR TITLE
Simplify UI: remove neon glows, reduce color noise, cleaner borders

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -4,23 +4,25 @@
 
 :root {
     --bg-main: #050505;
-    --bg-surface: #0f0f13;
-    --bg-panel: #1a1a20;
+    --bg-surface: #0a0a0e;
+    --bg-panel: #111116;
 
-    --text-main: #e0e0e0;
-    --text-dim: #888888;
+    --text-main: #c8c8c8;
+    --text-dim: #555;
 
     --accent-pink: #ff00ff;
     --accent-yellow: #f2ff00;
     --accent-cyan: #00ffff;
     --accent-red: #ff3333;
 
+    --border-subtle: #1e1e24;
+
     --font-header: 'Grenze Gotisch', cursive;
     --font-sub: 'Orbitron', sans-serif;
     --font-body: 'Special Elite', cursive;
     --font-ui: 'Share Tech Mono', monospace;
 
-    --border-style: 2px solid;
+    --border-style: 1px solid;
     --glow-pink: 0 0 10px rgba(255, 0, 255, 0.5);
     --glow-yellow: 0 0 10px rgba(242, 255, 0, 0.5);
     --glow-cyan: 0 0 10px rgba(0, 255, 255, 0.5);
@@ -57,7 +59,7 @@ body {
     background-size: 100% 2px, 3px 100%;
     pointer-events: none;
     z-index: 9999;
-    opacity: 0.6;
+    opacity: 0.3;
 }
 
 .container {
@@ -82,10 +84,10 @@ h1.cyber-glitch {
     text-align: center;
     font-size: 3rem;
     margin: 10px 0 20px 0;
-    text-shadow: var(--glow-yellow);
+    text-shadow: none;
     text-transform: uppercase;
     letter-spacing: 4px;
-    border-bottom: var(--border-style) var(--accent-pink);
+    border-bottom: none;
     padding-bottom: 10px;
 }
 
@@ -134,28 +136,28 @@ h1.cyber-glitch::after {
 
 h3 {
     font-family: var(--font-sub);
-    color: var(--accent-cyan);
-    font-size: 1.2rem;
-    border-bottom: 1px dashed var(--accent-cyan);
+    color: var(--text-main);
+    font-size: 1.1rem;
+    border-bottom: none;
     padding-bottom: 5px;
     margin-top: 0;
 }
 
 h4 {
     font-family: var(--font-sub);
-    color: var(--accent-pink);
-    font-size: 1rem;
+    color: var(--text-dim);
+    font-size: 0.85rem;
     margin: 10px 0;
     text-transform: uppercase;
+    letter-spacing: 1px;
 }
 
 /* Character Sheet */
 .character-sheet {
     background: var(--bg-surface);
-    border: 1px solid var(--accent-cyan);
+    border: 1px solid var(--border-subtle);
     padding: 15px;
-    margin-bottom: 20px;
-    box-shadow: var(--glow-cyan);
+    margin-bottom: 16px;
 }
 
 .stats {
@@ -172,12 +174,12 @@ h4 {
 
 .stat {
     font-family: var(--font-ui);
-    background: var(--bg-panel);
-    border: 1px solid var(--text-dim);
-    padding: 8px;
+    background: transparent;
+    border: none;
+    padding: 6px 4px;
     text-align: center;
-    font-size: 1.1rem;
-    color: var(--accent-yellow);
+    font-size: 1rem;
+    color: var(--text-main);
 }
 
 /* Game Area */
@@ -187,12 +189,12 @@ h4 {
 
 .game-area {
     background: var(--bg-panel);
-    border: var(--border-style) var(--accent-pink);
+    border: 1px solid var(--border-subtle);
+    border-radius: 4px;
     padding: 20px;
-    margin-bottom: 20px;
-    min-height: 150px;
-    box-shadow: inset 0 0 20px rgba(0,0,0,0.8);
-    font-size: 1.1rem;
+    margin-bottom: 16px;
+    min-height: 120px;
+    font-size: 1.05rem;
 }
 
 #gameText p {
@@ -214,23 +216,24 @@ h4 {
 
 button {
     background: transparent;
-    border: var(--border-style) var(--accent-cyan);
-    color: var(--accent-cyan);
+    border: 1px solid #2a2a30;
+    color: var(--text-main);
     font-family: var(--font-sub);
-    font-size: 1rem;
-    padding: 15px;
+    font-size: 0.9rem;
+    padding: 14px;
     cursor: pointer;
     text-transform: uppercase;
     font-weight: bold;
     transition: all 0.2s;
     position: relative;
-    clip-path: polygon(10px 0, 100% 0, 100% calc(100% - 10px), calc(100% - 10px) 100%, 0 100%, 0 10px);
+    clip-path: none;
+    border-radius: 4px;
 }
 
 button:hover:not(:disabled) {
-    background: var(--accent-cyan);
-    color: var(--bg-main);
-    box-shadow: var(--glow-cyan);
+    background: rgba(255, 255, 255, 0.05);
+    color: var(--accent-cyan);
+    border-color: var(--accent-cyan);
 }
 
 button:disabled {
@@ -241,23 +244,24 @@ button:disabled {
 }
 
 #levelUpBtn {
-    border-color: var(--accent-yellow);
+    border-color: rgba(242, 255, 0, 0.3);
     color: var(--accent-yellow);
-    animation: pulse 1.5s infinite;
+    animation: pulse 2s infinite;
 }
 
 @keyframes pulse {
-    0% { box-shadow: 0 0 5px var(--accent-yellow); }
-    50% { box-shadow: 0 0 20px var(--accent-yellow); }
-    100% { box-shadow: 0 0 5px var(--accent-yellow); }
+    0% { border-color: rgba(242, 255, 0, 0.15); }
+    50% { border-color: rgba(242, 255, 0, 0.5); }
+    100% { border-color: rgba(242, 255, 0, 0.15); }
 }
 
 /* Inventory */
 .inventory {
     background: var(--bg-surface);
-    border-top: var(--border-style) var(--accent-pink);
-    padding: 15px;
-    margin-bottom: 20px;
+    border: 1px solid var(--border-subtle);
+    border-radius: 4px;
+    padding: 12px 15px;
+    margin-bottom: 16px;
 }
 
 .inventory-item {
@@ -280,9 +284,8 @@ button:disabled {
 }
 
 .inventory-item.equipped {
-    border-color: var(--accent-pink);
-    color: var(--accent-pink);
-    box-shadow: var(--glow-pink);
+    border-color: var(--accent-cyan);
+    color: var(--accent-cyan);
 }
 
 .inventory-item.non-selectable {
@@ -329,13 +332,13 @@ button:disabled {
 /* Shared panel style for Challenges + Log */
 .challenges,
 .log {
-    background: #000;
-    border: 1px solid var(--text-dim);
+    background: var(--bg-surface);
+    border: 1px solid var(--border-subtle);
     padding: 6px 10px 10px;
     font-family: var(--font-ui);
     font-size: 0.85rem;
     color: var(--text-dim);
-    border-radius: 5px;
+    border-radius: 4px;
 }
 
 .side-panels {
@@ -498,14 +501,16 @@ button:disabled {
     padding: 6px 12px;
     min-width: 80px;
     clip-path: none;
-    font-size: 0.9rem;
-    background: rgba(0, 255, 255, 0.1);
-    border: 1px solid var(--accent-cyan);
+    font-size: 0.85rem;
+    background: transparent;
+    border: 1px solid #2a2a30;
+    border-radius: 3px;
 }
 
 .buy-btn:hover:not(:disabled) {
-    background: var(--accent-cyan);
-    color: var(--bg-main);
+    background: rgba(255, 255, 255, 0.05);
+    color: var(--accent-cyan);
+    border-color: var(--accent-cyan);
 }
 
 
@@ -566,8 +571,7 @@ button:disabled {
 
 .modal-content {
     background: var(--bg-surface);
-    border: var(--border-style) var(--accent-yellow);
-    box-shadow: var(--glow-yellow);
+    border: 1px solid #2a2a30;
     color: var(--text-main);
     padding: 20px;
     width: 90%;
@@ -575,6 +579,7 @@ button:disabled {
     max-height: 90vh;
     overflow-y: auto;
     position: relative;
+    border-radius: 6px;
 }
 
 .modal-close {
@@ -638,15 +643,14 @@ button:disabled {
     bottom: 100%;
     left: 50%;
     transform: translateX(-50%);
-    background: var(--accent-cyan);
-    color: var(--bg-main);
-    padding: 5px 10px;
+    background: #1e1e24;
+    color: var(--text-main);
+    padding: 4px 8px;
     font-family: var(--font-ui);
-    font-size: 0.8rem;
+    font-size: 0.75rem;
     white-space: nowrap;
     z-index: 10;
-    box-shadow: var(--glow-cyan);
-    border-radius: 5px;
+    border-radius: 3px;
     margin-bottom: 5px;
 }
 
@@ -665,23 +669,23 @@ button:disabled {
 .toast {
     background: rgba(15, 15, 19, 0.95);
     color: var(--text-main);
-    border-left: 4px solid var(--accent-cyan);
-    padding: 15px 20px;
-    min-width: 250px;
+    border-left: 3px solid var(--text-dim);
+    padding: 12px 16px;
+    min-width: 220px;
     font-family: var(--font-sub);
-    font-size: 0.9rem;
-    box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+    font-size: 0.85rem;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
     animation: slideIn 0.3s ease-out, fadeOut 0.5s ease-in 2.5s forwards;
     display: flex;
     align-items: center;
     gap: 10px;
     backdrop-filter: blur(4px);
-    clip-path: polygon(0 0, 100% 0, 100% calc(100% - 10px), calc(100% - 10px) 100%, 0 100%);
+    border-radius: 4px;
 }
 
-.toast.success { border-color: var(--accent-yellow); color: var(--accent-yellow); box-shadow: var(--glow-yellow); }
-.toast.danger { border-color: var(--accent-red); color: var(--accent-red); box-shadow: 0 0 5px rgba(255, 51, 51, 0.5); }
-.toast.info { border-color: var(--accent-cyan); color: var(--accent-cyan); box-shadow: var(--glow-cyan); }
+.toast.success { border-left-color: var(--accent-yellow); color: var(--accent-yellow); }
+.toast.danger { border-left-color: var(--accent-red); color: var(--accent-red); }
+.toast.info { border-left-color: var(--accent-cyan); color: var(--accent-cyan); }
 
 @keyframes slideIn {
     from { transform: translateX(100%); opacity: 0; }
@@ -760,7 +764,8 @@ body.in-combat .log {
     animation: battle-start 0.4s ease-out;
     position: relative;
     overflow: hidden;
-    border: 1px solid rgba(255, 255, 255, 0.1);
+    border: 1px solid var(--border-subtle);
+    border-radius: 4px;
 }
 
 @keyframes battle-start {
@@ -1177,19 +1182,19 @@ body.in-combat .log {
     text-align: center;
     animation: fadeIn 0.5s;
     background: var(--bg-surface);
-    border: var(--border-style) var(--accent-yellow);
-    box-shadow: var(--glow-yellow);
+    border: 1px solid var(--border-subtle);
     padding: 20px;
     display: flex;
     flex-direction: column;
     align-items: center;
+    border-radius: 4px;
 }
 
 .victory-screen h2 {
     color: var(--accent-yellow);
     font-family: var(--font-header);
     font-size: 2.5rem;
-    text-shadow: 0 0 10px var(--accent-yellow);
+    text-shadow: none;
     margin: 0 0 20px 0;
     text-transform: uppercase;
 }
@@ -1198,20 +1203,21 @@ body.in-combat .log {
     max-width: 150px;
     height: auto;
     image-rendering: pixelated;
-    border: 2px solid var(--accent-yellow);
-    box-shadow: 0 0 20px rgba(242, 255, 0, 0.3);
+    border: 1px solid var(--border-subtle);
     margin-bottom: 20px;
     background: #000;
+    border-radius: 4px;
 }
 
 .victory-rewards {
-    background: rgba(242, 255, 0, 0.05);
-    border: 1px solid var(--accent-yellow);
+    background: rgba(242, 255, 0, 0.03);
+    border: 1px solid var(--border-subtle);
     padding: 20px;
     margin: 20px 0;
     font-family: var(--font-ui);
     width: 100%;
     max-width: 400px;
+    border-radius: 4px;
 }
 
 .victory-rewards p {
@@ -1239,21 +1245,20 @@ body.in-combat .log {
     text-align: center;
     animation: fadeIn 0.5s;
     background: var(--bg-surface);
-    border: var(--border-style) var(--text-dim); /* Default fallback */
+    border: 1px solid var(--border-subtle);
     padding: 20px;
     display: flex;
     flex-direction: column;
     align-items: center;
+    border-radius: 4px;
 }
 
 .end-screen.victory {
-    border-color: var(--accent-yellow);
-    box-shadow: var(--glow-yellow);
+    border-color: rgba(242, 255, 0, 0.2);
 }
 
 .end-screen.defeat {
-    border-color: var(--accent-red);
-    box-shadow: 0 0 10px rgba(255, 51, 51, 0.5);
+    border-color: rgba(255, 51, 51, 0.2);
 }
 
 .end-screen h2 {
@@ -1265,12 +1270,10 @@ body.in-combat .log {
 
 .end-screen.victory h2 {
     color: var(--accent-yellow);
-    text-shadow: 0 0 10px var(--accent-yellow);
 }
 
 .end-screen.defeat h2 {
     color: var(--accent-red);
-    text-shadow: 0 0 10px var(--accent-red);
 }
 
 .end-screen-visual {
@@ -1287,13 +1290,11 @@ body.in-combat .log {
 }
 
 .end-screen.victory .end-screen-visual img {
-    border-color: var(--accent-yellow);
-    box-shadow: 0 0 20px rgba(242, 255, 0, 0.3);
+    border-color: rgba(242, 255, 0, 0.2);
 }
 
 .end-screen.defeat .end-screen-visual img {
-    border-color: var(--accent-red);
-    box-shadow: 0 0 20px rgba(255, 51, 51, 0.3);
+    border-color: rgba(255, 51, 51, 0.2);
     filter: grayscale(100%) contrast(1.2);
 }
 
@@ -1308,13 +1309,13 @@ body.in-combat .log {
 }
 
 .end-screen.victory .end-screen-stats {
-    background: rgba(242, 255, 0, 0.05);
-    border-color: var(--accent-yellow);
+    background: rgba(242, 255, 0, 0.03);
+    border-color: var(--border-subtle);
 }
 
 .end-screen.defeat .end-screen-stats {
-    background: rgba(255, 51, 51, 0.05);
-    border-color: var(--accent-red);
+    background: rgba(255, 51, 51, 0.03);
+    border-color: var(--border-subtle);
 }
 
 .stat-row {
@@ -1341,7 +1342,7 @@ body.in-combat .log {
 
 @media (max-width: 600px) {
     h1.cyber-glitch {
-        font-size: 2rem;
+        font-size: 1.8rem;
         letter-spacing: 2px;
         margin: 4px 0 10px 0;
         padding-bottom: 6px;
@@ -1417,40 +1418,26 @@ body.in-combat #fleeBtn {
     grid-column: 1 / -1;
 }
 
-/* Attack button - cyan (accurate) */
+/* Attack button */
 #attackBtn {
-    border-color: var(--accent-cyan);
-    color: var(--accent-cyan);
+    color: var(--text-main);
 }
 
-#attackBtn:hover:not(:disabled) {
-    background: var(--accent-cyan);
-    color: var(--bg-main);
-    box-shadow: var(--glow-cyan);
-}
-
-/* Power Attack button - yellow (risky, high damage) */
+/* Power Attack button */
 #powerAttackBtn {
-    border-color: var(--accent-yellow);
-    color: var(--accent-yellow);
+    color: var(--text-main);
 }
 
-#powerAttackBtn:hover:not(:disabled) {
-    background: var(--accent-yellow);
-    color: var(--bg-main);
-    box-shadow: var(--glow-yellow);
-}
-
-/* Flee button - muted (retreat option) */
+/* Flee button - muted */
 #fleeBtn {
-    border-color: var(--text-dim);
     color: var(--text-dim);
+    border-color: #1e1e24;
 }
 
 #fleeBtn:hover:not(:disabled) {
-    background: var(--text-dim);
-    color: var(--bg-main);
-    box-shadow: none;
+    color: var(--text-main);
+    border-color: #2a2a30;
+    background: rgba(255, 255, 255, 0.03);
 }
 
 /* Button sub-label text */
@@ -1490,17 +1477,14 @@ body.in-combat #fleeBtn {
 
 .dice-roll-panel {
     background: var(--bg-panel);
-    border: 1px solid var(--accent-yellow);
-    border-radius: 14px;
+    border: 1px solid #2a2a30;
+    border-radius: 10px;
     padding: 14px 18px 12px;
     display: flex;
     flex-direction: column;
     align-items: center;
     gap: 8px;
-    box-shadow:
-        0 0 0 1px rgba(242, 255, 0, 0.08),
-        0 0 30px rgba(242, 255, 0, 0.12),
-        0 -6px 24px rgba(0, 0, 0, 0.9);
+    box-shadow: 0 -6px 24px rgba(0, 0, 0, 0.9);
     cursor: pointer;
     user-select: none;
 }
@@ -1552,11 +1536,11 @@ body.in-combat #fleeBtn {
     gap: 1px;
 }
 
-.die-face[data-type="d4"]  { border-color: var(--accent-pink);   box-shadow: 0 0 8px rgba(255,0,255,0.2); }
-.die-face[data-type="d6"]  { border-color: var(--accent-yellow); box-shadow: 0 0 8px rgba(242,255,0,0.2); }
-.die-face[data-type="d8"]  { border-color: var(--accent-cyan);   box-shadow: 0 0 8px rgba(0,255,255,0.2); }
-.die-face[data-type="d10"] { border-color: var(--accent-pink);   box-shadow: 0 0 8px rgba(255,0,255,0.2); }
-.die-face[data-type="d12"] { border-color: var(--accent-cyan);   box-shadow: 0 0 8px rgba(0,255,255,0.2); }
+.die-face[data-type="d4"]  { border-color: #2a2a30; }
+.die-face[data-type="d6"]  { border-color: #2a2a30; }
+.die-face[data-type="d8"]  { border-color: #2a2a30; }
+.die-face[data-type="d10"] { border-color: #2a2a30; }
+.die-face[data-type="d12"] { border-color: #2a2a30; }
 
 /* Die type label */
 .die-type-label {
@@ -1652,17 +1636,14 @@ body.in-combat #fleeBtn {
 
 .dice-roll-outcome.success {
     color: var(--accent-yellow);
-    text-shadow: 0 0 16px rgba(242, 255, 0, 0.9), 0 0 32px rgba(242, 255, 0, 0.4);
 }
 
 .dice-roll-outcome.failure {
     color: var(--accent-red);
-    text-shadow: 0 0 16px rgba(255, 51, 51, 0.9), 0 0 32px rgba(255, 51, 51, 0.4);
 }
 
 .dice-roll-outcome.neutral {
     color: var(--accent-cyan);
-    text-shadow: 0 0 16px rgba(0, 255, 255, 0.6);
 }
 
 /* Tap hint */


### PR DESCRIPTION
- Replace colored borders (cyan, pink) with subtle dark gray borders
- Remove all box-shadow glow effects from panels, buttons, and modals
- Remove title underline and text-shadow glow
- Tone down CRT overlay opacity (0.6 → 0.3)
- Use neutral text colors for stats and buttons instead of accent colors
- Replace clip-path button styling with simple border-radius
- Simplify dice overlay, toasts, tooltips, and end screens
- Add consistent border-radius (4px) across panels
- Keep accent colors only for meaningful highlights (level up, outcomes)

https://claude.ai/code/session_01HNVMDAV7NuPGKidP59v3qP