### PR TITLE
feat: redesign battle screen for clarity and snappy feel

### DIFF
--- a/game.js
+++ b/game.js
@@ -485,12 +485,15 @@ function animateBattleAttack(attacker) {
     setTimeout(() => actorEl.classList.remove('attack-lunge-right', 'attack-lunge-left'), 260);
 }
 
-function showFloatingCombatText(target, amount, { crit = false, heal = false } = {}) {
+function showFloatingCombatText(target, amount, { crit = false, heal = false, miss = false } = {}) {
     const targetEl = document.getElementById(target === 'player' ? 'battle-player-actor' : 'battle-enemy-actor');
     if (!targetEl) return;
 
     const float = document.createElement('div');
-    if (amount === 0 && target === 'player') {
+    if (miss) {
+        float.className = 'floating-combat-text miss';
+        float.textContent = 'PRASLYDO';
+    } else if (amount === 0 && target === 'player') {
         float.className = 'floating-combat-text block';
         float.textContent = 'BLOKUOTA';
     } else {
@@ -498,14 +501,34 @@ function showFloatingCombatText(target, amount, { crit = false, heal = false } =
         float.textContent = `${heal ? '+' : '-'}${amount}${crit ? ' CRIT!' : ''}`;
     }
     targetEl.appendChild(float);
-    setTimeout(() => float.remove(), 850);
+    setTimeout(() => float.remove(), 900);
 }
 
-function pushCombatFeed(type, text) {
+/**
+ * Briefly shakes the battle interface for player-damage impact feedback.
+ */
+function shakeBattleScreen() {
+    const el = document.getElementById('battle-interface');
+    if (!el) return;
+    el.classList.remove('battle-shake');
+    // Force reflow so the animation restarts even on repeat hits
+    void el.offsetWidth;
+    el.classList.add('battle-shake');
+    setTimeout(() => el.classList.remove('battle-shake'), 320);
+}
+
+function pushCombatFeed(type, text, iconOverride) {
     if (!gameState.inCombat) return;
+    const iconByType = {
+        player: 'swords',
+        enemy: 'skull',
+        warning: 'priority_high',
+        info: 'info'
+    };
     const entry = {
         type,
         text,
+        icon: iconOverride || iconByType[type] || 'info',
         turn: gameState.combatTurn
     };
     gameState.combatFeed.unshift(entry);
@@ -517,6 +540,7 @@ function pushCombatFeed(type, text) {
     if (!feedEl) return;
     feedEl.innerHTML = gameState.combatFeed.map(item => `
         <div class="battle-feed-item ${item.type}">
+            <span class="battle-feed-icon"><span class="material-symbols-outlined">${item.icon}</span></span>
             <span class="battle-feed-turn">#${item.turn}</span>
             <span class="battle-feed-text">${item.text}</span>
         </div>
@@ -532,6 +556,7 @@ function triggerDamageEffect() {
         characterSheetEl.classList.add('player-damage-flash');
         setTimeout(() => characterSheetEl.classList.remove('player-damage-flash'), 400);
     }
+    shakeBattleScreen();
 }
 
 /**
@@ -662,21 +687,33 @@ function updateUI() {
 
         if (gameState.currentMonster) {
             const hpBar = document.getElementById('battle-enemy-hp-bar');
+            const hpGhost = document.getElementById('battle-enemy-hp-ghost');
             if (hpBar) {
                 const pct = Math.max(0, (gameState.currentMonster.currentHp / gameState.currentMonster.hp) * 100);
                 hpBar.style.width = `${pct}%`;
+                // Ghost bar drains after a short delay so the damage reads as "lost HP"
+                if (hpGhost) hpGhost.style.width = `${pct}%`;
             }
             const monsterHpTextEl = document.getElementById('monster-hp');
             if (monsterHpTextEl) {
                 monsterHpTextEl.textContent = Math.max(0, gameState.currentMonster.currentHp);
             }
+
+            // Hit chance = ((7 - difficulty) / 6) * 100; updates if player swaps weapons mid-fight (no hit bonus yet but future-proof)
+            const hitEl = document.getElementById('battle-hit-chance');
+            if (hitEl) {
+                const chance = Math.max(0, Math.min(100, Math.round(((7 - gameState.currentMonster.difficulty) / 6) * 100)));
+                hitEl.textContent = `${chance}%`;
+            }
         }
 
         // Player HP bar
         const playerHpBarFill = document.getElementById('battle-player-hp-bar-fill');
+        const playerHpGhost = document.getElementById('battle-player-hp-ghost');
         if (playerHpBarFill) {
             const pct = Math.max(0, (gameState.hp / gameState.maxHp) * 100);
             playerHpBarFill.style.width = `${pct}%`;
+            if (playerHpGhost) playerHpGhost.style.width = `${pct}%`;
             playerHpBarFill.className = 'arena-hp-fill player-hp';
             if (pct <= 25) {
                 playerHpBarFill.classList.add('low-hp');
@@ -684,6 +721,9 @@ function updateUI() {
                 playerHpBarFill.classList.add('medium-hp');
             }
         }
+
+        // Next-action intent hint for auto-battle
+        updateBattleIntent();
 
         // Quick Items (Potions & Weapons) — compact inline
         const quickItemsEl = document.getElementById('battle-quick-items');
@@ -1058,7 +1098,7 @@ function startCombat(monster) {
     gameState.combatTurn = 1;
     gameState.combatFeed = [];
     gameState.autoBattle = true;
-    gameState.autoBattleDelay = 500;
+    gameState.autoBattleDelay = 350;
     document.body.classList.add('in-combat');
 
     let damageString = gameState.playerDamage;
@@ -1067,69 +1107,105 @@ function startCombat(monster) {
     const isBoss = monster.name === FORTRESS_LORD.name;
     const isTough = TOUGH_MONSTERS.some(m => m.name === monster.name);
     const threatClass = isBoss ? 'boss' : isTough ? 'tough' : 'weak';
+    const threatPipCount = isBoss ? 3 : isTough ? 2 : 1;
+    const threatPips = '<span class="material-symbols-outlined">skull</span>'.repeat(threatPipCount);
+
+    // Hit chance % from d6 vs difficulty: (7 - difficulty) / 6
+    const hitChance = Math.max(0, Math.min(100, Math.round(((7 - scaledMonster.difficulty) / 6) * 100)));
 
     let text = `
-        <div class="battle-interface">
-            <!-- Arena: Loop Hero style - characters facing each other -->
+        <div class="battle-interface" id="battle-interface">
+            <!-- Header ribbon: round + boss tag -->
+            <div class="battle-header">
+                <span class="battle-header-title">
+                    ${isBoss ? '<span class="boss-tag">BOSS</span>' : '<span class="material-symbols-outlined" style="font-size:0.95rem;">swords</span> Kova'}
+                </span>
+                <span class="round-chip">Raundas <span id="battle-turn-counter">${gameState.combatTurn}</span></span>
+            </div>
+
+            <!-- Arena: two combatants facing each other -->
             <div class="battle-arena">
                 <!-- Player side -->
                 <div class="arena-combatant player-side">
                     <div class="arena-name">${gameState.playerName}</div>
                     <div class="arena-sprite" id="battle-player-actor">
-                        <span class="material-symbols-outlined">swords</span>
+                        <span class="material-symbols-outlined">person</span>
                     </div>
-                    <div class="arena-hp-bar">
-                        <div id="battle-player-hp-bar-fill" class="arena-hp-fill player-hp" style="width: 100%;"></div>
+                    <div class="arena-hp-wrap">
+                        <div class="arena-hp-bar">
+                            <div class="arena-hp-ghost" id="battle-player-hp-ghost" style="width: 100%;"></div>
+                            <div id="battle-player-hp-bar-fill" class="arena-hp-fill player-hp" style="width: 100%;"></div>
+                            <div class="arena-hp-text"><span id="battle-player-hp">${gameState.hp}</span>/<span id="battle-player-max-hp">${gameState.maxHp}</span></div>
+                        </div>
                     </div>
-                    <div class="arena-hp-text"><span id="battle-player-hp">${gameState.hp}</span>/<span id="battle-player-max-hp">${gameState.maxHp}</span></div>
                 </div>
 
-                <!-- Center info -->
+                <!-- Center VS -->
                 <div class="arena-center">
-                    <div class="arena-round" id="battle-turn-counter">${gameState.combatTurn}</div>
                     <div class="arena-vs">VS</div>
                 </div>
 
                 <!-- Enemy side -->
                 <div class="arena-combatant enemy-side ${threatClass}">
-                    <div class="arena-name">${scaledMonster.name}</div>
+                    <div class="arena-name">
+                        ${scaledMonster.name}
+                        <span class="threat-pips" aria-hidden="true">${threatPips}</span>
+                    </div>
                     <div class="arena-sprite" id="battle-enemy-actor">
                         <img src="https://img.itch.zone/aW1hZ2UvMTQwODA2NC84MjAzNTg5LmdpZg==/original/CIfGNn.gif" alt="${scaledMonster.name}" id="monster-stats-display">
                     </div>
-                    <div class="arena-hp-bar">
-                        <div id="battle-enemy-hp-bar" class="arena-hp-fill enemy-hp" style="width: 100%;"></div>
+                    <div class="arena-hp-wrap">
+                        <div class="arena-hp-bar">
+                            <div class="arena-hp-ghost" id="battle-enemy-hp-ghost" style="width: 100%;"></div>
+                            <div id="battle-enemy-hp-bar" class="arena-hp-fill enemy-hp" style="width: 100%;"></div>
+                            <div class="arena-hp-segments"></div>
+                            <div class="arena-hp-text"><span id="monster-hp">${scaledMonster.hp}</span>/${scaledMonster.hp}</div>
+                        </div>
                     </div>
-                    <div class="arena-hp-text"><span id="monster-hp">${scaledMonster.hp}</span>/${scaledMonster.hp}</div>
                 </div>
             </div>
 
-            <!-- Compact stats bar -->
+            <!-- Split stats bar: YOU (left) | HIT% (center) | THREAT (right) -->
             <div class="battle-stats-bar">
-                <div class="battle-stat-item">
-                    <span class="material-symbols-outlined">flash_on</span>
-                    <span id="battle-player-damage">${damageString}</span>
+                <div class="stat-card you">
+                    <div class="battle-stat-item dmg" title="Žala">
+                        <span class="material-symbols-outlined">flash_on</span>
+                        <span id="battle-player-damage">${damageString}</span>
+                    </div>
+                    <div class="battle-stat-item def" title="Apsauga">
+                        <span class="material-symbols-outlined">shield</span>
+                        <span id="battle-player-defense">${gameState.playerDefense}</span>
+                    </div>
                 </div>
-                <div class="battle-stat-item">
-                    <span class="material-symbols-outlined">shield</span>
-                    <span id="battle-player-defense">${gameState.playerDefense}</span>
+                <div class="stat-card" style="background: rgba(242,255,0,0.05); border-color: rgba(242,255,0,0.2);">
+                    <div class="battle-stat-item hit" title="Pataikymo tikimybė">
+                        <span class="material-symbols-outlined">my_location</span>
+                        <span id="battle-hit-chance">${hitChance}%</span>
+                    </div>
                 </div>
-                <div class="battle-stat-item target">
-                    <span class="material-symbols-outlined">target</span>
-                    ${scaledMonster.difficulty}+
-                </div>
-                <div class="battle-stat-item" id="battle-quick-items">
-                    <!-- Populated by updateUI -->
+                <div class="stat-card enemy ${isBoss ? 'boss' : ''}">
+                    <div class="battle-stat-item threat" title="Priešo žala">
+                        <span class="material-symbols-outlined">swords</span>
+                        <span>${scaledMonster.damage}</span>
+                    </div>
                 </div>
             </div>
 
-            <!-- Auto-battle controls -->
+            <!-- Quick items tray (potions, weapon swaps) -->
+            <div id="battle-quick-items" class="battle-quick-items-row"></div>
+
+            <!-- Auto-battle controls + intent hint -->
             <div class="auto-battle-row">
                 <button id="auto-battle-btn" class="auto-battle-btn active" onclick="toggleAutoBattle()">
-                    <span class="material-symbols-outlined">pause</span> Auto: ON
+                    <span class="material-symbols-outlined">pause</span> <span>Auto</span>
                 </button>
                 <button id="auto-speed-btn" class="auto-battle-btn auto-speed-btn" onclick="cycleAutoBattleSpeed()">
-                    <span class="material-symbols-outlined">bolt</span> <span id="auto-battle-speed-label">x1.5</span>
+                    <span class="material-symbols-outlined">bolt</span> <span id="auto-battle-speed-label">x2</span>
                 </button>
+                <div class="battle-intent" id="battle-intent">
+                    <span class="intent-label">Toliau:</span>
+                    <span class="intent-value" id="battle-intent-value">Pulti</span>
+                </div>
             </div>
 
             <!-- Unified battle feed -->
@@ -1231,6 +1307,7 @@ async function performAttack(isPowerAttack) {
         }
     } else {
         // Dark Fort rule: enemy only attacks when you miss
+        showFloatingCombatText('enemy', 0, { miss: true });
         log(isPowerAttack ? `Galingas smūgis nepavyko!` : `Nepataikei į ${monster.name}.`);
         combatLogEl.innerHTML = `<p class='warning'>${isPowerAttack ? 'Galingas smūgis nepavyko (nepataikei)!' : `Nepataikei į ${monster.name}.`}</p>`;
         pushCombatFeed('warning', `Nepataikei į ${monster.name}.`);
@@ -1279,9 +1356,11 @@ function toggleAutoBattle() {
     if (btn) {
         btn.classList.toggle('active', gameState.autoBattle);
         btn.innerHTML = gameState.autoBattle
-            ? '<span class="material-symbols-outlined">pause</span> Auto: ON'
-            : '<span class="material-symbols-outlined">play_arrow</span> Auto: OFF';
+            ? '<span class="material-symbols-outlined">pause</span> <span>Auto</span>'
+            : '<span class="material-symbols-outlined">play_arrow</span> <span>Manual</span>';
     }
+    updateBattleIntent();
+    updateUI();
     if (gameState.autoBattle) {
         runAutoBattle();
     }
@@ -1290,11 +1369,38 @@ function toggleAutoBattle() {
 function cycleAutoBattleSpeed() {
     if (gameState.autoBattleDelay === 500) gameState.autoBattleDelay = 350;
     else if (gameState.autoBattleDelay === 350) gameState.autoBattleDelay = 200;
+    else if (gameState.autoBattleDelay === 200) gameState.autoBattleDelay = 100;
     else gameState.autoBattleDelay = 500;
 
     const label = document.getElementById('auto-battle-speed-label');
     if (label) {
-        label.textContent = gameState.autoBattleDelay <= 200 ? 'x3' : gameState.autoBattleDelay <= 350 ? 'x2' : 'x1.5';
+        label.textContent = gameState.autoBattleDelay <= 100 ? 'x4' : gameState.autoBattleDelay <= 200 ? 'x3' : gameState.autoBattleDelay <= 350 ? 'x2' : 'x1.5';
+    }
+}
+
+/**
+ * Refreshes the "Next: ..." intent hint so the player can predict the
+ * auto-battle's next move (Unicorn Overlord style).
+ */
+function updateBattleIntent() {
+    const intentEl = document.getElementById('battle-intent');
+    const valueEl = document.getElementById('battle-intent-value');
+    if (!intentEl || !valueEl) return;
+    if (!gameState.inCombat || !gameState.autoBattle || gameState.monsterDying) {
+        intentEl.classList.add('hidden');
+        return;
+    }
+    intentEl.classList.remove('hidden');
+    const action = pickAutoBattleAction();
+    valueEl.className = 'intent-value';
+    if (action === 'potion') {
+        valueEl.textContent = 'Mikstūra';
+        valueEl.classList.add('potion');
+    } else if (action === 'power') {
+        valueEl.textContent = 'Galingas';
+        valueEl.classList.add('power');
+    } else {
+        valueEl.textContent = 'Pulti';
     }
 }
 
@@ -1353,7 +1459,7 @@ async function runAutoBattle() {
     const btn = document.getElementById('auto-battle-btn');
     if (btn) {
         btn.classList.remove('active');
-        btn.innerHTML = '<span class="material-symbols-outlined">play_arrow</span> Auto: OFF';
+        btn.innerHTML = '<span class="material-symbols-outlined">play_arrow</span> <span>Manual</span>';
     }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -847,14 +847,15 @@ body.in-combat .log {
 }
 
 /* =============================================================================
-   BATTLE INTERFACE - Loop Hero inspired minimal arena
+   BATTLE INTERFACE - Unicorn Overlord / Loop Hero / Dragon Quest inspired
+   Clear, minimal, snappy — big HP bars, focal enemy, calm palette.
    ========================================================================== */
 
 .battle-interface {
     display: flex;
     flex-direction: column;
     background: var(--bg-surface);
-    animation: battle-start 0.4s ease-out;
+    animation: battle-start 0.35s ease-out;
     position: relative;
     overflow: hidden;
     border: 1px solid var(--border-subtle);
@@ -862,8 +863,54 @@ body.in-combat .log {
 }
 
 @keyframes battle-start {
-    from { transform: scale(0.97); opacity: 0; }
-    to { transform: scale(1); opacity: 1; }
+    from { transform: scale(0.98); opacity: 0; }
+    to   { transform: scale(1);    opacity: 1; }
+}
+
+/* --- Round ribbon above arena (Dragon Quest-esque header) --- */
+.battle-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 6px 12px;
+    background: rgba(0,0,0,0.55);
+    border-bottom: 1px solid rgba(255,255,255,0.05);
+    font-family: var(--font-ui);
+    font-size: 0.68rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+}
+
+.battle-header .round-chip {
+    color: var(--accent-yellow);
+    background: rgba(242,255,0,0.08);
+    border: 1px solid rgba(242,255,0,0.25);
+    padding: 2px 8px;
+    border-radius: 10px;
+    letter-spacing: 0.14em;
+}
+
+.battle-header .battle-header-title {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.battle-header .boss-tag {
+    color: var(--accent-yellow);
+    background: rgba(242,255,0,0.1);
+    border: 1px solid rgba(242,255,0,0.4);
+    padding: 2px 8px;
+    border-radius: 2px;
+    font-weight: bold;
+    letter-spacing: 0.18em;
+    animation: boss-pulse 1.8s ease-in-out infinite;
+}
+
+@keyframes boss-pulse {
+    0%, 100% { box-shadow: 0 0 0 rgba(242,255,0,0.15); }
+    50%      { box-shadow: 0 0 12px rgba(242,255,0,0.4); }
 }
 
 /* --- Arena: two combatants facing each other --- */
@@ -872,12 +919,26 @@ body.in-combat .log {
     grid-template-columns: 1fr auto 1fr;
     gap: 0;
     align-items: end;
-    padding: 16px 12px 10px;
+    padding: 20px 14px 22px;
     background:
-        radial-gradient(ellipse at center bottom, rgba(255,255,255,0.03) 0%, transparent 70%),
-        linear-gradient(180deg, #080810, #0a0a12);
-    min-height: 140px;
+        radial-gradient(ellipse 60% 40% at center 92%, rgba(0,255,255,0.06) 0%, transparent 70%),
+        radial-gradient(ellipse 40% 30% at 20% 100%, rgba(0,255,255,0.04) 0%, transparent 60%),
+        radial-gradient(ellipse 40% 30% at 80% 100%, rgba(255,51,51,0.04) 0%, transparent 60%),
+        linear-gradient(180deg, #06060c 0%, #0a0a14 60%, #050509 100%);
+    min-height: 160px;
     position: relative;
+}
+
+/* Horizon / stage floor line */
+.battle-arena::before {
+    content: "";
+    position: absolute;
+    left: 8%;
+    right: 8%;
+    bottom: 14px;
+    height: 1px;
+    background: linear-gradient(90deg, transparent 0%, rgba(255,255,255,0.14) 50%, transparent 100%);
+    pointer-events: none;
 }
 
 /* Each combatant column */
@@ -885,60 +946,95 @@ body.in-combat .log {
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 4px;
+    gap: 6px;
     position: relative;
-    min-width: 0; /* prevent grid blowout */
+    min-width: 0;
 }
 
 .arena-name {
     font-family: var(--font-ui);
-    font-size: 0.7rem;
-    color: var(--text-dim);
+    font-size: 0.72rem;
+    color: var(--text-main);
     text-transform: uppercase;
-    letter-spacing: 0.08em;
+    letter-spacing: 0.1em;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
     max-width: 100%;
     text-align: center;
+    font-weight: bold;
 }
 
 .player-side .arena-name { color: var(--accent-cyan); }
-.enemy-side .arena-name { color: var(--accent-red); }
+.enemy-side .arena-name  { color: var(--accent-red); }
 .enemy-side.boss .arena-name { color: var(--accent-yellow); }
 
-/* Sprites */
+/* Threat pips under enemy name (weak=1, tough=2, boss=3 skulls) */
+.threat-pips {
+    display: inline-flex;
+    gap: 2px;
+    margin-left: 4px;
+    font-size: 0.65rem;
+    color: var(--accent-red);
+    opacity: 0.85;
+    vertical-align: middle;
+}
+.enemy-side.boss .threat-pips { color: var(--accent-yellow); }
+
+/* --- Sprites --- */
 .arena-sprite {
     position: relative;
-    width: 72px;
-    height: 72px;
+    width: 84px;
+    height: 84px;
     display: flex;
     align-items: center;
     justify-content: center;
     border: 1px solid rgba(255,255,255,0.08);
     background: #000;
-    overflow: hidden;
+    overflow: visible;
     flex-shrink: 0;
+    border-radius: 3px;
+    transition: box-shadow 0.15s;
 }
+
+/* Ground shadow */
+.arena-sprite::after {
+    content: "";
+    position: absolute;
+    left: 50%;
+    bottom: -10px;
+    transform: translateX(-50%);
+    width: 70%;
+    height: 6px;
+    background: radial-gradient(ellipse, rgba(0,0,0,0.7) 0%, transparent 70%);
+    pointer-events: none;
+    z-index: 1;
+}
+
+.arena-sprite > * { position: relative; z-index: 2; }
 
 .player-side .arena-sprite {
     border-color: rgba(0,255,255,0.25);
-    box-shadow: 0 0 12px rgba(0,255,255,0.08);
+    box-shadow: 0 0 12px rgba(0,255,255,0.06), inset 0 0 18px rgba(0,255,255,0.04);
+    background: linear-gradient(180deg, #02121a, #010509);
 }
 
 .player-side .arena-sprite .material-symbols-outlined {
-    font-size: 2rem;
+    font-size: 2.4rem;
     color: var(--accent-cyan);
+    text-shadow: 0 0 10px rgba(0,255,255,0.55);
 }
 
 .player-side .arena-sprite.active-turn {
-    box-shadow: 0 0 18px rgba(0,255,255,0.25);
-    border-color: rgba(0,255,255,0.5);
+    box-shadow: 0 0 22px rgba(0,255,255,0.35), inset 0 0 18px rgba(0,255,255,0.08);
+    border-color: rgba(0,255,255,0.65);
 }
 
 .enemy-side .arena-sprite {
-    border-color: rgba(255,51,51,0.25);
-    box-shadow: 0 0 12px rgba(255,51,51,0.08);
+    border-color: rgba(255,51,51,0.28);
+    box-shadow: 0 0 12px rgba(255,51,51,0.08), inset 0 0 20px rgba(255,51,51,0.04);
+    background: linear-gradient(180deg, #1a0404, #0a0202);
+    overflow: hidden;
 }
 
 .enemy-side .arena-sprite img {
@@ -950,74 +1046,121 @@ body.in-combat .log {
 }
 
 .enemy-side .arena-sprite.active-turn {
-    box-shadow: 0 0 18px rgba(255,51,51,0.25);
-    border-color: rgba(255,51,51,0.5);
+    box-shadow: 0 0 22px rgba(255,51,51,0.35), inset 0 0 20px rgba(255,51,51,0.08);
+    border-color: rgba(255,51,51,0.65);
 }
 
 .enemy-side.boss .arena-sprite {
-    width: 88px;
-    height: 88px;
-    border-color: rgba(242,255,0,0.3);
-    box-shadow: 0 0 16px rgba(242,255,0,0.12);
+    width: 108px;
+    height: 108px;
+    border-color: rgba(242,255,0,0.35);
+    box-shadow: 0 0 18px rgba(242,255,0,0.16), inset 0 0 24px rgba(242,255,0,0.06);
 }
 
-/* HP bars under sprites */
+/* --- HP bars (the star of the show) --- */
+.arena-hp-wrap {
+    position: relative;
+    width: 110px;
+    max-width: 100%;
+}
+
 .arena-hp-bar {
-    width: 80px;
-    height: 6px;
-    background: rgba(255,255,255,0.12);
+    position: relative;
+    width: 100%;
+    height: 12px;
+    background: rgba(255,255,255,0.08);
     overflow: hidden;
-    border-radius: 3px;
+    border-radius: 2px;
+    border: 1px solid rgba(0,0,0,0.6);
+    box-shadow: inset 0 1px 2px rgba(0,0,0,0.6);
+}
+
+/* Ghost bar: lingers for a moment after damage, then catches up */
+.arena-hp-ghost {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 100%;
+    background: rgba(255,255,255,0.45);
+    transition: width 0.25s ease-out 0.35s;
+    pointer-events: none;
+    z-index: 1;
 }
 
 .arena-hp-fill {
+    position: relative;
     height: 100%;
     width: 100%;
-    transition: width 0.3s ease-out;
+    transition: width 0.25s ease-out;
+    z-index: 2;
+    background-image: linear-gradient(180deg, rgba(255,255,255,0.22), rgba(0,0,0,0.15));
 }
 
-.arena-hp-fill.player-hp { background: var(--accent-cyan); }
-.arena-hp-fill.player-hp.medium-hp { background: var(--accent-yellow); }
-.arena-hp-fill.player-hp.low-hp { background: var(--accent-red); }
-.arena-hp-fill.enemy-hp { background: var(--accent-red); }
-.enemy-side.boss .arena-hp-fill.enemy-hp { background: var(--accent-yellow); }
+.arena-hp-fill.player-hp              { background-color: #2ee66a; }
+.arena-hp-fill.player-hp.medium-hp    { background-color: var(--accent-yellow); }
+.arena-hp-fill.player-hp.low-hp       { background-color: var(--accent-red); animation: hp-danger-pulse 1s ease-in-out infinite; }
+.arena-hp-fill.enemy-hp               { background-color: var(--accent-red); }
+.enemy-side.boss .arena-hp-fill.enemy-hp {
+    background-image: linear-gradient(180deg, #fff49b, #f2ff00 45%, #b58900 100%);
+    background-color: var(--accent-yellow);
+}
+
+@keyframes hp-danger-pulse {
+    0%, 100% { filter: brightness(1); }
+    50%      { filter: brightness(1.35); }
+}
+
+/* Segmented tick marks overlay (boss = 5 segments, others hidden) */
+.arena-hp-segments {
+    position: absolute;
+    inset: 0;
+    z-index: 3;
+    display: none;
+    pointer-events: none;
+    background-image: repeating-linear-gradient(
+        90deg,
+        transparent 0,
+        transparent calc(20% - 1px),
+        rgba(0,0,0,0.55) calc(20% - 1px),
+        rgba(0,0,0,0.55) 20%
+    );
+}
+.enemy-side.boss .arena-hp-segments { display: block; }
 
 .arena-hp-text {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     font-family: var(--font-ui);
-    font-size: 0.65rem;
-    color: var(--text-dim);
-    text-align: center;
+    font-size: 0.68rem;
+    font-weight: bold;
+    color: #fff;
+    text-shadow: 0 1px 2px rgba(0,0,0,0.95), 0 0 4px rgba(0,0,0,0.8);
+    letter-spacing: 0.04em;
+    z-index: 4;
+    pointer-events: none;
 }
 
-/* Center VS / round counter */
+/* --- Center: round + VS stack --- */
 .arena-center {
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 4px;
-    padding: 0 10px;
+    gap: 6px;
+    padding: 0 12px;
     align-self: center;
-}
-
-.arena-round {
-    font-family: var(--font-sub);
-    font-size: 0.65rem;
-    color: var(--accent-yellow);
-    background: rgba(0,0,0,0.6);
-    border: 1px solid rgba(242,255,0,0.2);
-    width: 26px;
-    height: 26px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: 50%;
 }
 
 .arena-vs {
     font-family: var(--font-sub);
-    font-size: 0.6rem;
-    color: rgba(255,255,255,0.2);
-    letter-spacing: 0.1em;
+    font-size: 0.72rem;
+    font-weight: 900;
+    color: rgba(255,255,255,0.28);
+    letter-spacing: 0.18em;
+    text-shadow: 0 0 8px rgba(255,255,255,0.1);
 }
 
 /* Attack lunge animations */
@@ -1061,168 +1204,289 @@ body.in-combat .log {
 .floating-combat-text.heal { color: #6eff8f; }
 .floating-combat-text.crit {
     color: var(--accent-yellow);
-    font-size: 1.05rem;
-    text-shadow: 0 0 16px var(--accent-yellow), 0 1px 4px rgba(0,0,0,0.8);
-}
-.floating-combat-text.block {
-    color: var(--text-dim);
-    font-size: 0.85rem;
-    text-shadow: 0 0 12px currentColor, 0 1px 4px rgba(0,0,0,0.8);
+    font-size: 1.35rem;
+    font-weight: 900;
+    letter-spacing: 0.04em;
+    text-shadow: 0 0 18px var(--accent-yellow), 0 0 6px #fff, 0 1px 4px rgba(0,0,0,0.85);
+    animation: float-combat-crit 0.9s ease-out forwards;
 }
 
-/* --- Compact stats bar --- */
+@keyframes float-combat-crit {
+    0%   { opacity: 0; transform: translate(-50%, -50%) scale(0.6) rotate(-4deg); }
+    15%  { opacity: 1; transform: translate(-50%, -55%) scale(1.3) rotate(0deg); }
+    30%  { transform: translate(-50%, -60%) scale(1.1); }
+    100% { opacity: 0; transform: translate(-50%, -130%) scale(1); }
+}
+
+.floating-combat-text.block {
+    color: #9fd4ff;
+    font-size: 0.8rem;
+    font-style: italic;
+    text-shadow: 0 0 10px #6aa8d6, 0 1px 4px rgba(0,0,0,0.85);
+}
+
+.floating-combat-text.miss {
+    color: #b0b0b0;
+    font-size: 0.85rem;
+    font-style: italic;
+    font-weight: bold;
+    letter-spacing: 0.08em;
+    text-shadow: 0 0 8px rgba(0,0,0,0.95), 0 1px 2px rgba(0,0,0,0.8);
+}
+
+/* Screen shake on player damage */
+@keyframes screen-shake {
+    0%, 100% { transform: translate(0, 0); }
+    20% { transform: translate(-3px, 2px); }
+    40% { transform: translate(3px, -1px); }
+    60% { transform: translate(-2px, -2px); }
+    80% { transform: translate(2px, 1px); }
+}
+
+.battle-shake {
+    animation: screen-shake 0.3s ease-in-out;
+}
+
+/* --- Stats bar: split into "you" vs "enemy" info cards --- */
 .battle-stats-bar {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    padding: 7px 12px;
-    background: rgba(0,0,0,0.4);
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    align-items: stretch;
+    padding: 8px 10px;
+    gap: 8px;
+    background: rgba(0,0,0,0.55);
     border-top: 1px solid rgba(255,255,255,0.06);
     border-bottom: 1px solid rgba(255,255,255,0.06);
     font-family: var(--font-ui);
-    font-size: 0.8rem;
-    color: var(--text-dim);
-    flex-wrap: nowrap;
-    overflow-x: auto;
+    font-size: 0.78rem;
+    color: var(--text-main);
 }
+
+.stat-card {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    padding: 4px 8px;
+    border-radius: 3px;
+    background: rgba(255,255,255,0.02);
+    border: 1px solid rgba(255,255,255,0.05);
+    min-width: 0;
+}
+
+.stat-card.you    { border-left: 2px solid var(--accent-cyan); }
+.stat-card.enemy  { border-right: 2px solid var(--accent-red); }
+.stat-card.enemy.boss { border-right-color: var(--accent-yellow); }
 
 .battle-stat-item {
     display: inline-flex;
     align-items: center;
-    gap: 2px;
+    gap: 3px;
     white-space: nowrap;
-    flex-shrink: 0;
 }
 
 .battle-stat-item .material-symbols-outlined {
     font-size: 1rem;
+    opacity: 0.9;
 }
 
-.battle-stat-item:nth-child(1) { color: var(--accent-red); }   /* damage */
-.battle-stat-item:nth-child(2) { color: var(--accent-cyan); }  /* defense */
-.battle-stat-item.target { color: var(--text-dim); }
+.battle-stat-item.dmg     { color: var(--accent-red); }
+.battle-stat-item.def     { color: var(--accent-cyan); }
+.battle-stat-item.hit     { color: var(--accent-yellow); font-weight: bold; }
+.battle-stat-item.threat  { color: var(--text-dim); }
 
-/* Quick items inline in stats bar */
-#battle-quick-items {
-    display: inline-flex;
-    gap: 4px;
-    margin-left: auto;
+/* Quick items tray (outside main grid so they don't compete with core stats) */
+.battle-quick-items-row {
+    display: flex;
+    justify-content: center;
+    gap: 6px;
+    padding: 6px 10px;
+    background: rgba(0,0,0,0.35);
+    border-bottom: 1px solid rgba(255,255,255,0.05);
+    min-height: 0;
 }
+
+.battle-quick-items-row:empty { display: none; }
 
 .battle-item-btn {
-    background: rgba(0, 0, 0, 0.5);
-    border: 1px solid rgba(255,255,255,0.12);
-    color: var(--text-main);
-    padding: 2px 8px;
-    font-size: 0.7rem;
+    background: rgba(255,0,255,0.06);
+    border: 1px solid rgba(255,0,255,0.3);
+    color: var(--accent-pink);
+    padding: 4px 10px;
+    font-size: 0.72rem;
     font-family: var(--font-ui);
     cursor: pointer;
     display: inline-flex;
     align-items: center;
-    gap: 3px;
+    gap: 4px;
     transition: all 0.15s;
     text-transform: none;
     clip-path: none;
     border-radius: 2px;
+    font-weight: bold;
 }
 
 .battle-item-btn:hover {
+    background: rgba(255, 0, 255, 0.18);
+    color: #fff;
     border-color: var(--accent-pink);
-    color: var(--accent-pink);
-    background: rgba(255, 0, 255, 0.1);
+    box-shadow: 0 0 10px rgba(255,0,255,0.3);
 }
 
 .battle-item-btn .material-symbols-outlined {
-    font-size: 0.8rem;
+    font-size: 0.95rem;
 }
 
 /* --- Auto-battle controls --- */
 .auto-battle-row {
     display: flex;
     justify-content: center;
-    padding: 5px 12px;
-    background: rgba(0, 0, 0, 0.25);
-    gap: 6px;
+    align-items: center;
+    padding: 7px 10px;
+    background: rgba(0, 0, 0, 0.4);
+    gap: 8px;
+    border-bottom: 1px solid rgba(255,255,255,0.04);
 }
 
 .auto-battle-btn {
-    background: rgba(0, 0, 0, 0.5);
-    border: 1px solid rgba(255,255,255,0.12);
+    background: rgba(0, 0, 0, 0.55);
+    border: 1px solid rgba(255,255,255,0.14);
     color: var(--text-dim);
-    padding: 3px 10px;
-    font-size: 0.7rem;
+    padding: 5px 12px;
+    font-size: 0.72rem;
     font-family: var(--font-ui);
     cursor: pointer;
-    display: flex;
+    display: inline-flex;
     align-items: center;
-    gap: 3px;
-    text-transform: none;
+    gap: 4px;
+    text-transform: uppercase;
     clip-path: none;
-    letter-spacing: 0.05em;
+    letter-spacing: 0.08em;
+    font-weight: bold;
     transition: all 0.15s;
     border-radius: 2px;
 }
 
 .auto-battle-btn .material-symbols-outlined {
-    font-size: 0.85rem;
+    font-size: 0.95rem;
 }
 
 .auto-battle-btn:hover {
     border-color: var(--accent-cyan);
     color: var(--accent-cyan);
+    background: rgba(0,255,255,0.08);
 }
 
 .auto-battle-btn.active {
     border-color: var(--accent-yellow);
     color: var(--accent-yellow);
-    background: rgba(255, 200, 0, 0.08);
+    background: rgba(242,255,0,0.1);
+    box-shadow: 0 0 8px rgba(242,255,0,0.15);
 }
 
 .auto-speed-btn {
-    color: var(--text-dim);
-    border-color: rgba(255, 255, 255, 0.12);
+    color: var(--text-main);
+    border-color: rgba(255, 255, 255, 0.18);
 }
 
 .auto-speed-btn:hover {
     color: var(--accent-pink);
     border-color: var(--accent-pink);
+    background: rgba(255,0,255,0.08);
 }
 
-/* --- Battle feed: compact action log --- */
+/* "Next action" intent hint (Unicorn Overlord-style predictive cue) */
+.battle-intent {
+    margin-left: auto;
+    font-size: 0.65rem;
+    font-family: var(--font-ui);
+    color: var(--text-dim);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    opacity: 0.85;
+}
+
+.battle-intent .intent-label { color: var(--text-dim); }
+.battle-intent .intent-value {
+    color: var(--accent-cyan);
+    font-weight: bold;
+}
+.battle-intent .intent-value.power  { color: var(--accent-yellow); }
+.battle-intent .intent-value.potion { color: #6eff8f; }
+.battle-intent .material-symbols-outlined { font-size: 0.9rem; }
+.battle-intent.hidden { display: none; }
+
+/* --- Battle feed: icon-prefixed action log --- */
 .battle-feed {
     display: flex;
     flex-direction: column;
-    gap: 2px;
-    padding: 6px 10px;
-    background: rgba(0, 0, 0, 0.35);
-    max-height: 90px;
+    gap: 3px;
+    padding: 8px 10px;
+    background: rgba(0, 0, 0, 0.4);
+    max-height: 110px;
     overflow-y: auto;
+    scrollbar-width: thin;
+}
+
+.battle-feed::-webkit-scrollbar { width: 4px; }
+.battle-feed::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.1); }
+
+@keyframes feed-slide-in {
+    from { opacity: 0; transform: translateX(-6px); }
+    to   { opacity: 1; transform: translateX(0); }
 }
 
 .battle-feed-item {
     display: flex;
     align-items: center;
-    gap: 6px;
+    gap: 8px;
     font-family: var(--font-ui);
-    font-size: 0.7rem;
-    padding: 3px 5px;
+    font-size: 0.72rem;
+    padding: 4px 8px;
     border-left: 2px solid var(--text-dim);
-    opacity: 0.9;
+    background: rgba(255,255,255,0.02);
+    border-radius: 0 2px 2px 0;
+    animation: feed-slide-in 0.2s ease-out;
+    transition: opacity 0.3s;
 }
 
-.battle-feed-item.player { border-left-color: var(--accent-cyan); }
-.battle-feed-item.enemy { border-left-color: var(--accent-red); }
-.battle-feed-item.warning { border-left-color: var(--accent-yellow); }
-.battle-feed-item.info { border-left-color: rgba(255,255,255,0.2); }
+.battle-feed-item:nth-child(n+4) { opacity: 0.55; }
+.battle-feed-item:nth-child(n+5) { opacity: 0.35; }
+
+.battle-feed-item.player  { border-left-color: var(--accent-cyan);  background: rgba(0,255,255,0.04); }
+.battle-feed-item.enemy   { border-left-color: var(--accent-red);   background: rgba(255,51,51,0.04); }
+.battle-feed-item.warning { border-left-color: var(--accent-yellow); background: rgba(242,255,0,0.04); }
+.battle-feed-item.info    { border-left-color: rgba(255,255,255,0.2); }
+
+.battle-feed-icon {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+}
+.battle-feed-icon .material-symbols-outlined { font-size: 0.95rem; }
+
+.battle-feed-item.player  .battle-feed-icon { color: var(--accent-cyan); }
+.battle-feed-item.enemy   .battle-feed-icon { color: var(--accent-red); }
+.battle-feed-item.warning .battle-feed-icon { color: var(--accent-yellow); }
+.battle-feed-item.info    .battle-feed-icon { color: var(--text-dim); }
 
 .battle-feed-turn {
     color: rgba(255,255,255,0.3);
     min-width: 22px;
-    font-size: 0.65rem;
+    font-size: 0.62rem;
+    text-align: center;
 }
 
 .battle-feed-text {
     color: var(--text-main);
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 /* Hidden battle log - kept for compatibility */
@@ -1233,46 +1497,55 @@ body.in-combat .log {
 /* --- Mobile adjustments --- */
 @media (max-width: 480px) {
     .battle-arena {
-        padding: 12px 6px 8px;
-        min-height: 120px;
+        padding: 14px 6px 16px;
+        min-height: 140px;
     }
 
     .arena-sprite {
-        width: 56px;
-        height: 56px;
+        width: 64px;
+        height: 64px;
     }
 
     .enemy-side.boss .arena-sprite {
-        width: 68px;
-        height: 68px;
+        width: 84px;
+        height: 84px;
     }
 
+    .player-side .arena-sprite .material-symbols-outlined { font-size: 2rem; }
+
     .arena-name {
-        font-size: 0.6rem;
+        font-size: 0.62rem;
     }
 
     .arena-center {
         padding: 0 6px;
     }
 
-    .arena-hp-bar {
-        width: 60px;
-    }
+    .arena-hp-wrap { width: 82px; }
+    .arena-hp-bar { height: 10px; }
+    .arena-hp-text { font-size: 0.6rem; }
 
     .battle-stats-bar {
-        gap: 8px;
+        gap: 6px;
         font-size: 0.72rem;
-        padding: 6px 8px;
+        padding: 6px 6px;
     }
+    .stat-card { gap: 8px; padding: 3px 4px; }
+
+    .battle-header { font-size: 0.62rem; padding: 5px 10px; }
+    .battle-header .round-chip { padding: 1px 6px; }
 
     .battle-feed-item {
-        font-size: 0.65rem;
+        font-size: 0.68rem;
+        padding: 3px 6px;
     }
 
     .auto-battle-btn {
-        font-size: 0.65rem;
-        padding: 3px 6px;
+        font-size: 0.66rem;
+        padding: 4px 8px;
     }
+    .battle-intent { font-size: 0.6rem; }
+    .battle-intent .intent-label { display: none; } /* save space on small screens */
 }
 
 /* Victory Screen */
@@ -1507,13 +1780,38 @@ body.in-combat .log {
    COMBAT BUTTON STYLING
    ========================================================================== */
 
-/* Force 2-column layout during combat */
+/* During combat, dock the action buttons right beneath the arena as a
+   cohesive action bar (inspired by Dragon Quest command window). */
 body.in-combat .actions {
-    grid-template-columns: 1fr 1fr;
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: 6px;
+    padding: 10px;
+    margin-top: -1px; /* visually continuous with battle-interface */
+    background: rgba(0,0,0,0.55);
+    border: 1px solid var(--border-subtle);
+    border-top: none;
+    border-radius: 0 0 4px 4px;
+}
+
+body.in-combat #attackBtn,
+body.in-combat #powerAttackBtn,
+body.in-combat #fleeBtn {
+    margin: 0;
+    padding: 10px 6px;
+    font-size: 0.82rem;
+    border-radius: 2px;
 }
 
 body.in-combat #fleeBtn {
     grid-column: 1 / -1;
+    padding: 6px;
+    font-size: 0.72rem;
+    opacity: 0.75;
+}
+
+body.in-combat #fleeBtn:hover:not(:disabled) {
+    opacity: 1;
 }
 
 /* Start & Explore buttons */


### PR DESCRIPTION
Overhauls the combat UI around "clear, minimal, quick to read" — drawing
from Unicorn Overlord, Loop Hero, and Dragon Quest.

Arena
- Larger sprites with ground shadows and a subtle stage floor
- Taller HP bars (12px) with HP numbers rendered inside the fill
- Ghost-bar "lost HP" drain that lingers ~0.35s after each hit
- Round chip moved to a header ribbon above the arena

Readability
- Threat pips (skulls): 1/2/3 for weak / tough / boss
- Hit chance % replaces raw difficulty target ("67%" > "4+")
- Stats bar split into YOU / HIT% / ENEMY cards
- Quick items get their own row instead of crowding the stats bar

Controls
- Manual combat buttons (Attack / Power / Flee) dock beneath the
  battle interface as a single action bar when auto is off
- Auto toggle switches label to AUTO / MANUAL with play/pause icon
- Speed pill gains an x4 tier; default is now x2 (350ms) for snappier
  battles
- "Next:" intent hint predicts the auto-tactic (Pulti / Galingas /
  Mikstūra) so the player can follow the fight

Feedback
- PRASLYDO (miss) floating text, distinct from BLOKUOTA (block)
- Beefier CRIT! pop (scale + rotate)
- Brief screen shake on player damage
- Feed entries slide in with icons; older entries dim

Boss
- BOSS ribbon tag (pulsing) in the header
- Segmented golden HP bar (5 ticks) and larger sprite

https://claude.ai/code/session_01TxgACD3fqRFhRVRyGBpFdK